### PR TITLE
Disable absolute redirects in RWS

### DIFF
--- a/aws/rootdir/etc/nginx/sites-enabled.tpl/rws-all.ngx.tpl
+++ b/aws/rootdir/etc/nginx/sites-enabled.tpl/rws-all.ngx.tpl
@@ -3,6 +3,7 @@ server {
     real_ip_header    X-Forwarded-For;
     set_real_ip_from  VPC_CIDR;
     proxy_buffering off;	
+    absolute_redirect off;
 
     location = /leaderboard/jau/ {
         rewrite $ Ranking.html redirect;


### PR DESCRIPTION
Allows working redirects from `/leaderboard/jau` to `/leaderboard/jau/`.